### PR TITLE
連続王手千日手を検出できていなかった問題を修正

### DIFF
--- a/ShogiStudyThird/agent.cpp
+++ b/ShogiStudyThird/agent.cpp
@@ -443,6 +443,7 @@ bool SearchAgent::checkRepetitiveCheck(const Kyokumen& kyokumen,const std::vecto
 
 void SearchAgent::nodeCopy(const SearchNode* const origin, SearchNode* const copy)const {
 	copy->setEvaluation(origin->getEvaluation());
+	copy->move.setOute(origin->move.isOute());
 	for (auto& child : origin->children) {
 		copy->addCopyChild(child);
 	}


### PR DESCRIPTION
繰り返しがあった時の評価値コピーで王手の情報が抜けていたことが原因