### PR TITLE
探索温度の分散関数、着手決定関数、評価関数のバグ修正

### DIFF
--- a/ShogiStudyThird/agent.cpp
+++ b/ShogiStudyThird/agent.cpp
@@ -149,22 +149,15 @@ size_t SearchAgent::simulate(SearchNode* const root) {
 		}
 		//sortは静止探索後の方が評価値順の並びが維持されやすい　親スタートの静止探索ならその前後共にsortしてもいいかもしれない
 		std::sort(node->children.begin(), node->children.end(), [](SearchNode* a, SearchNode* b)->int {return a->eval < b->eval; });
-		double emin = std::numeric_limits<double>::max();
-		std::vector<double> evals;
-		for (const auto& child : node->children) {
-			const double eval = child->getEvaluation();
-			evals.push_back(eval);
-			if (eval < emin) {
-				emin = eval;
-			}
-		}
+		//sortしたのでfrontが最小値になっているはず
+		double emin = node->children.front()->eval;
 		double Z_e = 0;
-		for (const auto& eval : evals) {
-			Z_e += std::exp(-(eval - emin) / T_e);
+		for (const auto& child : node->children) {
+			Z_e += std::exp(-(child->eval - emin) / T_e);
 		}
 		double E = 0;
-		for (const auto& eval : evals) {
-			E -= eval * std::exp(-(eval - emin) / T_e) / Z_e;
+		for (const auto& child : node->children) {
+			E -= child->eval * std::exp(-(child->eval - emin) / T_e) / Z_e;
 		}
 		node->setEvaluation(E);
 		node->setMass(1);

--- a/ShogiStudyThird/agent.cpp
+++ b/ShogiStudyThird/agent.cpp
@@ -7,8 +7,8 @@ bool SearchAgent::leave_QsearchNode = false;
 bool SearchAgent::use_original_kyokumen_eval = false;
 bool SearchAgent::QS_relativeDepth = false;
 
-SearchAgent::SearchAgent(SearchTree& tree,int seed)
-	:tree(tree),engine(seed),root(tree.getRoot())
+SearchAgent::SearchAgent(SearchTree& tree, const double Ts,int seed)
+	:tree(tree),engine(seed),root(tree.getRoot()),Ts(Ts)
 {
 	
 	if (root != nullptr)
@@ -19,7 +19,7 @@ SearchAgent::SearchAgent(SearchTree& tree,int seed)
 }
 
 SearchAgent::SearchAgent(SearchAgent&& agent) noexcept
-	: tree(agent.tree), th(std::move(agent.th)),
+	: tree(agent.tree), th(std::move(agent.th)), Ts(agent.Ts),
 	root(agent.root), engine(std::move(agent.engine))
 {
 	alive = agent.alive.load();
@@ -52,7 +52,7 @@ size_t SearchAgent::simulate(SearchNode* const root) {
 		std::vector<dn> evals;
 		for (const auto& child : node->children) {
 			if (child->isSearchable()) {
-				double eval = child->getE_c();
+				double eval = child->getEs();
 				evals.push_back(std::make_pair(eval,child));
 				if (eval < CE) {
 					CE = eval;
@@ -67,7 +67,7 @@ size_t SearchAgent::simulate(SearchNode* const root) {
 			}
 			return 0;
 		}
-		const double T_c = node->getT_c();
+		const double T_c = node->getTs(Ts);
 		double Z = 0;
 		for (const auto& eval : evals) {
 			Z += std::exp(-(eval.first - CE) / T_c);

--- a/ShogiStudyThird/agent.h
+++ b/ShogiStudyThird/agent.h
@@ -13,7 +13,7 @@ private:
 	static bool use_original_kyokumen_eval;
 	static bool QS_relativeDepth;
 public:
-	SearchAgent(SearchTree& tree, int seed);
+	SearchAgent(SearchTree& tree, const double Ts, int seed);
 	SearchAgent(SearchAgent&&)noexcept;
 	SearchAgent() = delete;
 	SearchAgent(const SearchAgent&) = delete;
@@ -32,6 +32,7 @@ private:
 	SearchPlayer player;
 	std::atomic_bool alive;//生きているかどうか
 	std::thread th;
+	const double Ts;
 
 	//値域 [0,1.0) のランダムな値
 	std::uniform_real_distribution<double> random{ 0, 1.0 };

--- a/ShogiStudyThird/apery_feature.h
+++ b/ShogiStudyThird/apery_feature.h
@@ -75,11 +75,10 @@ namespace apery {
 		void proceed(const Kyokumen& before, const Move& move);
 		void recede(const Kyokumen& before,const koma::Koma moved,const koma::Koma captured, const Move move, const EvalSum& cache);
 		EvalSum getCache() { return sum; }
-		bool operator==(const apery_feat& rhs)const {
-			return idlist.list0 == rhs.idlist.list0 && idlist.list1 == rhs.idlist.list1 && idlist.material == idlist.material && sum.p == rhs.sum.p;
-		}
+		bool operator==(const apery_feat& rhs)const;
 		bool operator!=(const apery_feat& rhs)const {
 			return !operator==(rhs);
 		}
+		std::string toString()const;
 	};
 }

--- a/ShogiStudyThird/commander.cpp
+++ b/ShogiStudyThird/commander.cpp
@@ -112,14 +112,15 @@ void Commander::coutOption() {
 	cout << "option name QSearch_Use_RelativeDepth type check default false" << endl;
 	cout << "option name QSearch_depth type string default 0" << endl;
 	cout << "option name Use_Original_Kyokumen_Eval type check default false" << endl;
-	cout << "option name T_choice_const type string default 120" << endl;
-	cout << "option name Tc_functionCode type spin default 0 min 0 max 7" << endl;
-	cout << "option name T_choice_mass_parent type string default 1" << endl;
-	cout << "option name T_choice_children_masses type string default 1" << endl;
+	cout << "option name Ts_disperseFunc type spin default 0 min 0 max 1" << endl;
+	cout << "option name Ts_min type string default 40" << endl;
+	cout << "option name Ts_max type string default 200" << endl;
+	cout << "option name Ts_functionCode type spin default 0 min 0 max 1" << endl;
+	cout << "option name Ts_funcParam type string default 1" << endl;
 	cout << "option name T_eval type string default 40" << endl;
 	cout << "option name T_depth type string default 100" << endl;
-	cout << "option name Ec_functionCode type spin default 18 min 0 max 19" << endl;
-	cout << "option name Ec_c type string default 0.5" << endl;
+	cout << "option name Es_functionCode type spin default 18 min 0 max 19" << endl;
+	cout << "option name Es_funcParam type string default 0.5" << endl;
 	cout << "option name NodeMaxNum type string default 100000000" << endl;
 	cout << "option name PV_functionCode type spin default 0 min 0 max 2" << endl;
 	cout << "option name PV_const type string default 0" << endl;
@@ -155,17 +156,17 @@ void Commander::setOption(const std::vector<std::string>& token) {
 		else if (token[2] == "Use_Original_Kyokumen_Eval") {
 			SearchAgent::setUseOriginalKyokumenEval(token[4] == "true");
 		}
-		else if (token[2] == "T_choice_const") {
-			SearchNode::setTcConst(std::stod(token[4]));
+		else if (token[2] == "Ts_min") {
+			Ts_min = std::stod(token[4]);
 		}
-		else if (token[2] == "T_choice_mass_parent") {
-			SearchNode::setTcmp(std::stod(token[4]));
+		else if (token[2] == "Ts_max") {
+			Ts_max = std::stod(token[4]);
 		}
-		else if (token[2] == "T_choice_children_masses") {
-			SearchNode::setTcmc(std::stod(token[4]));
+		else if (token[2] == "Ts_funcParam") {
+			SearchNode::setTsFuncParam(std::stod(token[4]));
 		}
-		else if (token[2] == "Tc_functionCode") {
-			SearchNode::setTcFuncCode(std::stoi(token[4]));
+		else if (token[2] == "Ts_functionCode") {
+			SearchNode::setTsFuncCode(std::stoi(token[4]));
 		}
 		else if (token[2] == "T_eval") {
 			SearchNode::setTeval(std::stod(token[4]));
@@ -173,11 +174,11 @@ void Commander::setOption(const std::vector<std::string>& token) {
 		else if (token[2] == "T_depth") {
 			SearchNode::setTdepth(std::stod(token[4]));
 		}
-		else if (token[2] == "Ec_functionCode") {
-			SearchNode::setEcFuncCode(std::stoi(token[4]));
+		else if (token[2] == "Es_functionCode") {
+			SearchNode::setEsFuncCode(std::stoi(token[4]));
 		}
-		else if (token[2] == "Ec_c") {
-			SearchNode::setEcC(std::stod(token[4]));
+		else if (token[2] == "Es_funcParam") {
+			SearchNode::setEsFuncParam(std::stod(token[4]));
 		}
 		else if (token[2] == "NodeMaxNum") {
 			tree.setNodeMaxsize(std::stoull(token[4]));
@@ -195,7 +196,6 @@ void Commander::paramInit() {
 	//usiによる設定前のデフォルト値
 
 	SearchNode::setTdepth(100);
-	SearchNode::setTcConst(120);
 	SearchNode::setTeval(40);
 	SearchNode::setQSearchDepth(0);
 	tree.setNodeMaxsize(150000000);
@@ -217,8 +217,11 @@ void Commander::gameInit() {
 
 void Commander::startAgent() {
 	assert(agents.empty());
+	const double minlog = std::log(Ts_min), maxlog = std::log(Ts_max);
+	const double delta = (maxlog - minlog) / (agentNum - 1);
 	for (int i = 0; i < agentNum; i++) {
-		agents.push_back(std::unique_ptr<SearchAgent>(new SearchAgent(tree, i)));
+		const double Ts = std::exp(minlog + delta * i);
+		agents.push_back(std::unique_ptr<SearchAgent>(new SearchAgent(tree, Ts, i)));
 	}
 }
 void Commander::stopAgent() {

--- a/ShogiStudyThird/commander.cpp
+++ b/ShogiStudyThird/commander.cpp
@@ -106,6 +106,7 @@ void Commander::coutOption() {
 	using namespace std;
 	//cout << "option name kppt_filepath type string default ./data/kppt_apery" << endl; //隠しオプション
 	cout << "option name leave_branchNode type check default false" << endl;
+	cout << "option name continuous_tree type check default true" << endl;
 	cout << "option name NumOfAgent type spin default 12 min 1 max 128" << endl;
 	cout << "option name Repetition_score type string default 0" << endl;
 	cout << "option name leave_qsearchNode type check default false" << endl;
@@ -119,7 +120,7 @@ void Commander::coutOption() {
 	cout << "option name Ts_funcParam type string default 1" << endl;
 	cout << "option name T_eval type string default 40" << endl;
 	cout << "option name T_depth type string default 100" << endl;
-	cout << "option name Es_functionCode type spin default 18 min 0 max 19" << endl;
+	cout << "option name Es_functionCode type spin default 18 min 0 max 20" << endl;
 	cout << "option name Es_funcParam type string default 0.5" << endl;
 	cout << "option name NodeMaxNum type string default 100000000" << endl;
 	cout << "option name PV_functionCode type spin default 0 min 0 max 3" << endl;
@@ -133,6 +134,9 @@ void Commander::setOption(const std::vector<std::string>& token) {
 		}
 		else if (token[2] == "leave_branchNode") {
 			tree.leave_branchNode = (token[4] == "true");
+		}
+		else if (token[2] == "continuous_tree") {
+			continuousTree = (token[4] == "true");
 		}
 		else if (token[2] == "kppt_filepath") {
 			//aperyのパラメータファイルの位置を指定する 隠しオプション
@@ -380,9 +384,15 @@ void Commander::position(const std::vector<std::string>& tokens) {
 	std::lock_guard<std::mutex> lock(treemtx);
 	stopAgent();
 	const auto prevRoot = tree.getRoot();
-	auto result = tree.set(tokens);
-	if (result.first) {
-		releaseAgentAndBranch(prevRoot, std::move(result.second));
+	if (continuousTree) {
+		auto result = tree.set(tokens);
+		if (result.first) {
+			releaseAgentAndBranch(prevRoot, std::move(result.second));
+		}
+		else {
+			tree.makeNewTree(tokens);
+			releaseAgentAndTree(prevRoot);
+		}
 	}
 	else {
 		tree.makeNewTree(tokens);

--- a/ShogiStudyThird/commander.h
+++ b/ShogiStudyThird/commander.h
@@ -12,6 +12,7 @@ private:
 	void setOption(const std::vector<std::string>& token);
 	void paramInit();
 	void gameInit();
+	void setTsDistribution();
 
 	void startAgent();
 	void stopAgent();
@@ -25,10 +26,12 @@ private:
 	SearchTree tree;
 	std::vector<std::unique_ptr<SearchAgent>> agents;
 	std::unique_ptr<std::thread> deleteThread;
-	unsigned agentNum = 6;
+	int agentNum = 6;
 	bool permitPonder;
 	double Ts_min = 40;
 	double Ts_max = 200;
+	int TsDistFuncNum = 0;
+	std::vector<double> TsDistribution;
 
 	std::thread go_thread;
 	std::thread info_thread;

--- a/ShogiStudyThird/commander.h
+++ b/ShogiStudyThird/commander.h
@@ -27,6 +27,8 @@ private:
 	std::unique_ptr<std::thread> deleteThread;
 	unsigned agentNum = 6;
 	bool permitPonder;
+	double Ts_min = 40;
+	double Ts_max = 200;
 
 	std::thread go_thread;
 	std::thread info_thread;

--- a/ShogiStudyThird/commander.h
+++ b/ShogiStudyThird/commander.h
@@ -28,6 +28,7 @@ private:
 	std::unique_ptr<std::thread> deleteThread;
 	int agentNum = 6;
 	bool permitPonder;
+	bool continuousTree = true;
 	double Ts_min = 40;
 	double Ts_max = 200;
 	int TsDistFuncNum = 0;

--- a/ShogiStudyThird/node.cpp
+++ b/ShogiStudyThird/node.cpp
@@ -195,6 +195,11 @@ double SearchNode::getEs()const {
 	}
 	case 19:
 		return eval * (1 - Es_c) + origin_eval * Es_c;
+	case 20: {
+		const double x = mass.load();
+		double p = Es_c * ((x >= 1) ? (1 / x*x) : 1);
+		return eval * (1.0 - p) + origin_eval * p;
+	}
 	}
 }
 

--- a/ShogiStudyThird/node.cpp
+++ b/ShogiStudyThird/node.cpp
@@ -9,15 +9,13 @@ double SearchNode::mateScore = 34000.0;//詰ませた側(勝った側)のscore
 double SearchNode::mateScoreBound = 30000.0;
 double SearchNode::mateOneScore = 20.0;
 double SearchNode::repetitionScore = -100;//先手側のscore（千日手のscoreは手番に依存する）
-double SearchNode::Tc_const = 60;
-double SearchNode::Tc_mp = 30;
-double SearchNode::Tc_mc = 20;
-int SearchNode::Tc_FunctionCode = 0;
+double SearchNode::Ts_c = 1.0;
+int SearchNode::Ts_FunctionCode = 0;
 double SearchNode::T_eval = 40;
 double SearchNode::T_depth = 90;
 int SearchNode::QS_depth = 0;
-int SearchNode::Ec_FunctionCode = 0;
-double SearchNode::Ec_c = 1.0;
+int SearchNode::Es_FunctionCode = 0;
+double SearchNode::Es_c = 1.0;
 int SearchNode::PV_FuncCode = 0;
 double SearchNode::PV_c = 0;
 
@@ -112,31 +110,14 @@ void SearchNode::setRepetitiveCheck() {
 	status = State::T;
 }
 
-double SearchNode::getT_c() const {
-	switch (Tc_FunctionCode)
+double SearchNode::getTs(const double baseT) const {
+	switch (Ts_FunctionCode)
 	{
 	case 0:
 	default:
-		return Tc_const;
+		return baseT;
 	case 1:
-		return Tc_const + Tc_mp * (mass - 1);
-	case 2:
-		return Tc_const + Tc_mc * getTcMcVariance();
-	case 3:
-		return Tc_const + Tc_mp * (mass - 1) * Tc_mc * getTcMcVariance();
-	case 4:
-		return std::max(Tc_const / ((mass - 1) / Tc_mc + 1), Tc_mp);
-	case 5:
-	{
-		const double x = mass;
-		if (x <= 3)return 120;
-		else if (x <= 7)return 165 - 15 * x;
-		else return 60;
-	}
-	case 6:
-		return std::max(Tc_const - Tc_mc * (mass - 1), Tc_mp);
-	case 7:
-		return Tc_const * std::pow(Tc_mp, mass.load());
+		return baseT * std::pow(Ts_c, mass.load());
 	}
 }
 
@@ -179,50 +160,41 @@ double SearchNode::getTcMcVarianceExpection()const {
 	return std::sqrt(variance / Z);
 }
 
-double SearchNode::getE_c()const {
-	switch (Ec_FunctionCode)
+double SearchNode::getEs()const {
+	switch (Es_FunctionCode)
 	{
 	case 0:
+	default:
 		return eval;
-	case 1:
-	case 2:
-	case 3:
-	case 4:
-	case 5:
-	case 6:
-	case 7:
-	case 8:
 	case 9:
-		return eval + Ec_c * origin_eval;
+		return eval + Es_c * origin_eval;
 	case 10:
 	case 11:
 	case 12:
 	{
 		const double e = eval.load();
-		return e + ((e > 0) ? -mass  * Ec_c : mass * Ec_c);
+		return e + ((e > 0) ? -mass  * Es_c : mass * Es_c);
 	}
 	case 13:
-		return eval * (1 - Ec_c * mass);
+		return eval * (1 - Es_c * mass);
 	case 14:
 	case 15:
-		return eval + Ec_c * mass;
+		return eval + Es_c * mass;
 	case 16: {
-		double p = Ec_c / (mass + 1);
+		double p = Es_c / (mass + 1);
 		return eval * (1.0 - p) + origin_eval * p;
 	}
 	case 17: {
-		double p = Ec_c / std::sqrt(mass + 1);
+		double p = Es_c / std::sqrt(mass + 1);
 		return eval * (1.0 - p) + origin_eval * p;
 	}
 	case 18: {
 		const double x = mass.load();
-		double p = Ec_c * ((x >= 1) ? (1 / x) : 1);
+		double p = Es_c * ((x >= 1) ? (1 / x) : 1);
 		return eval * (1.0 - p) + origin_eval * p;
 	}
 	case 19:
-		return eval * (1 - Ec_c) + origin_eval * Ec_c;
-	default:
-		return eval;
+		return eval * (1 - Es_c) + origin_eval * Es_c;
 	}
 }
 

--- a/ShogiStudyThird/node.h
+++ b/ShogiStudyThird/node.h
@@ -22,15 +22,13 @@ private:
 	static double mateScoreBound;
 	static double mateOneScore;
 	static double repetitionScore;
-	static double Tc_const;
-	static double Tc_mp;
-	static double Tc_mc;
-	static int Tc_FunctionCode;//探索指標の分散を期待値で重みづけするかどうかのフラグ
+	static double Ts_c;
+	static int Ts_FunctionCode;//探索指標の分散を期待値で重みづけするかどうかのフラグ
 	static double T_eval;
 	static double T_depth;
 	static int QS_depth;
-	static int Ec_FunctionCode;
-	static double Ec_c;
+	static int Es_FunctionCode;
+	static double Es_c;
 	static int PV_FuncCode;
 	static double PV_c;
 public:
@@ -40,18 +38,16 @@ public:
 	static void setRepScore(const double score) { repetitionScore = score; }
 	static double getMateScoreBound() { return mateScoreBound; }
 	static double getMateScore() { return mateScore; }
-	static void setTcConst(const double Tc) { Tc_const = Tc; }
-	static void setTcmp(const double Tc) { Tc_mp = Tc; }
-	static void setTcmc(const double Tc) { Tc_mc = Tc; }
-	static void setTcFuncCode(int c) { Tc_FunctionCode = c; }
+	static void setTsFuncParam(const double Ts) { Ts_c = Ts; }
+	static void setTsFuncCode(int c) { Ts_FunctionCode = c; }
 	static void setTeval(const double Te) { T_eval = Te; }
 	static void setTdepth(const double Td) { T_depth = Td; }
 	static void setQSearchDepth(const double mmqs) { QS_depth = mmqs; }
 	static double getTeval() { return T_eval; }
 	static double getTdepth() { return T_depth; }
 	static double getQSdepth() { return QS_depth; }
-	static void setEcFuncCode(const int code) { Ec_FunctionCode = code; }
-	static void setEcC(const double c) { Ec_c = c; }
+	static void setEsFuncCode(const int code) { Es_FunctionCode = code; }
+	static void setEsFuncParam(const double c) { Es_c = c; }
 	static void setPVFuncCode(const int code) { PV_FuncCode = code; }
 	static void setPVConst(const double b) { PV_c = b; }
 public:
@@ -77,8 +73,8 @@ public:
 	bool isLeaf()const { const auto s = status.load(); return s == State::N || s == State::iE; }
 	bool isTerminal()const { return status == State::T; }
 	bool isSearchable()const { const auto s = status.load(); return s == State::N || s == State::E; }
-	double getT_c()const;
-	double getE_c()const;
+	double getTs(const double baseT)const;
+	double getEs()const;
 	SearchNode* getBestChild()const;
 private:
 	double getTcMcVariance()const;

--- a/ShogiStudyThird/stest.cpp
+++ b/ShogiStudyThird/stest.cpp
@@ -170,6 +170,33 @@ bool ShogiTest::genCapMoveCheck(std::string parent_sfen) {
 	}
 }
 
+bool ShogiTest::checkFeature(std::string usiposition) {
+	auto token = usi::split(usiposition, ' ');
+	const auto moves = Move::usiToMoves(token);
+	std::vector<std::string> startpos;
+	for (const auto& str : token) {
+		if (str == "moves") break;
+		startpos.push_back(str);
+	}
+	Kyokumen kyokumen(startpos);
+	Feature feat(kyokumen);
+	for (int t = 0; t < moves.size(); t++) {
+		const auto move = moves[t];
+		feat.proceed(kyokumen, move);
+		kyokumen.proceed(move);
+		Feature stfeat(kyokumen);
+		if (feat != stfeat) {
+			std::cout << "feature test ng" << std::endl;
+			std::cout << feat.toString() << std::endl;
+			std::cout << stfeat.toString() << std::endl;
+			assert(0);
+			return false;
+		}
+	}
+	std::cout << "feature test ok" << std::endl;
+	return true;
+}
+
 bool ShogiTest::checkRecede(std::string sfen,const int depth) {
 	Kyokumen k(usi::split(sfen,' '));
 	Feature f(k);
@@ -334,6 +361,14 @@ void ShogiTest::test() {
 		string moves2 = "P*5b P*5d P*5e P*5h P*8a P*8b P*8c P*8e P*8f P*8h N*1b N*1c N*1e N*1g N*2d N*2e N*2f N*2g N*3a N*3d N*3e N*3f N*4a N*4d N*4e N*4f N*5b N*5d N*5e N*6a N*6b N*6d N*6e N*6f N*7a N*7c N*7e N*7g N*8a N*8b N*8c N*8e N*8f N*9b N*9c N*9e N*9f B*1b B*1c B*1e B*1g B*1h B*2d B*2e B*2f B*2g B*2h B*3a B*3d B*3e B*3f B*3i B*4a B*4d B*4e B*4f B*4h B*5b B*5d B*5e B*5h B*6a B*6b B*6d B*6e B*6f B*6h B*6i B*7a B*7c B*7e B*7g B*8a B*8b B*8c B*8e B*8f B*8h B*8i B*9b B*9c B*9e B*9f B*9h 1d1e 2c2d 3c3d 4c4d 6c6d 7d7e 9d9e 2a1c 4b3a 4b5c 3b3a 7b6b 7b7a 7b7c 7b8b 7b8c 5a4a 5a6a 1a1b 1a1c 9a9b 9a9c 2b1c 2b3a 8d8a 8d8b 8d8c 8d8e 8d8f 8d8g 8d8g+";
 		ShogiTest::genMoveCheck(str2, moves2);
 		ShogiTest::genCapMoveCheck(str2);
+	}
+	{
+		string str3 = "position startpos moves 2g2f 3c3d 7g7f 4c4d 5i6h 3a3b 4g4f 8b4b 3i4h 5a6b 9g9f 6b7b 9f9e 7b8b 4h4g 9a9b 4g5f 8b9a 8h6f 3b4c 4i5h 6c6d 2f2e 2b3c 6h7h 4a5b 4f4e 7a8b 6i6h 6a7a 6f7g 5c5d 2h2g 5b5c 3g3f 5d5e 2e2d 2c2d 5f5e 4d4e 2i3g 4c5b P*4d P*5d 3g4e 5d5e 4e5c+ 5b5c G*4c N*6e 7g6f 5e5f 5g5f P*5g 5h5i S*3h 2g2h 3h4g 4c5c 4b4d S*6b 5g5h+ 7h8h 5h6h 5i6h 4g5f+ 6b7a+ 8b7a G*6b 7a8b P*4e 4d4e 6f3c+ 2a3c 6g6f B*3i B*6c 3i2h+ 6b7b G*7a 5c6b 7a7b 6b7b S*7g 8i7g 6e7g+ 6h7g 4e4h+ G*7h G*7a N*7e N*8e 7b7a 8e7g+ 8h9g 8b7a 7e8c 9a8b 8c7a+ G*8f 8g8f G*8g 7h8g 7g8g 9g8g R*8i S*8h 4h5g G*7g 5g7g 8g7g 8i7i+ 8h7i 5f6f 7g6f G*6e 6f6g 6e5f 6g7h";
+		ShogiTest::checkFeature(str3);
+		string str2 = "position startpos moves 7g7f 3c3d 8h2b 3a2b 7i8h 2b3c 2g2f 8b2b 5i6h 5a6b B*6e 7c7d 6e4c+ 6c6d 6h7h 4a5b 4c5b 6a5b 9g9f 9c9d 4i5h 6b7b 1g1f 5b6c 5h6h 7b8b 8h7g 8c8d 3i4h 5c5d 1f1e 7a7b 3g3f 3c4d 4g4f 3d3e 6i7i 3e3f 4h4g 4d3e 4g5f 3e4f 2h3h B*2g 3h4h P*4g 4h4g 4f4g+ 5f4g R*4h 4g5f 2g3h+ P*4g 3h2i G*5h 4h4i+ 7i6i 2i1i 1e1d 1c1d 9f9e 9d9e 7h8h 3f3g+ 8h7h L*6a";
+		ShogiTest::checkFeature(str2);
+		string str1 = "position startpos moves 7g7f 3c3d 8h2b+ 3a2b 7i8h 2b3c 2g2f 8b2b 5i6h 5a6b B*6e 7c7d 6e4c+ 6c6d 6h7h 4a5b 4c5b 6a5b 9g9f 9c9d 4i5h 6b7b 1g1f 5b6c 5h6h 7b8b 8h7g 8c8d 3i4h 5c5d 1f1e 7a7b 3g3f 3c4d 4g4f 3d3e 6i7i 3e3f 4h4g 4d3e 4g5f 3e4f 2h3h B*2g 3h4h P*4g 4h4g 4f4g+ 5f4g R*4h 4g5f 2g3h+ P*4g 3h2i G*5h 4h4i+ 7i6i 2i1i 1e1d 1c1d 9f9e 9d9e 7h8h 3f3g+ 8h7h L*6a";
+		ShogiTest::checkFeature(str1);
 	}
 	{
 		string str4 = "position sfen 1r3g3/l2gk3l/3p4p/2p1+B1p2/p4s3/2P1P1Pb1/1+p1PSP2P/L2S3GL/1NGKNsr2 b N3Pn3p 1";

--- a/ShogiStudyThird/stest.h
+++ b/ShogiStudyThird/stest.h
@@ -13,6 +13,7 @@ public:
 	static bool genMoveCheck(std::string parent_sfen, std::string child_moves);
 	static bool genMoveCheck(std::string parent_sfen, Move pmove, std::string child_moves);
 	static bool genCapMoveCheck(std::string parent_sfen);
+	static bool checkFeature(std::string usiposition);
 	static bool checkRecede(std::string sfen,const int depth);
 	static bool checkRecedeR(Kyokumen& k, Feature& f, SearchNode* p, const int depth);
 	static void test();


### PR DESCRIPTION
探索温度の分散関数は、線形と対数、シグモイドの組み合わせで四通り実装した
着手決定関数は、(親ノードの深さ指標-1)が子ノード全体の深さ指標の期待値になるので、それに係数をかけたボーダーを用いて候補手の足切りを行う関数
評価関数にあったバグを修正　かなり指し手がまともになった