### PR TITLE
small fixes

### DIFF
--- a/ShogiStudyThird/commander.cpp
+++ b/ShogiStudyThird/commander.cpp
@@ -331,8 +331,8 @@ void Commander::info() {
 					//std::cout << "info string info" << std::endl;
 					const auto PV = tree.getPV();
 					std::string pvstr;
-					if (!PV.empty()) {
-						for (int i = 1; i < 7 && i < PV.size() && PV[i] != nullptr; i++) pvstr += PV[i]->move.toUSI()+' ';
+					if (PV.size() >= 2) {
+						for (int i = 1; i < 15 && i < PV.size() && PV[i] != nullptr; i++) pvstr += PV[i]->move.toUSI()+' ';
 						const auto& root = PV[0];
 						std::cout << std::fixed;
 						std::cout << "info pv " << pvstr << "depth " << std::setprecision(2) << root->mass << " seldepth " << (PV.size()-1)
@@ -363,14 +363,21 @@ void Commander::chakushu() {
 		std::cout << "bestmove resign" << std::endl;
 		return;
 	}
+	const auto PV = tree.getPV();
+	std::string pvstr;
+	if (PV.size() >= 2) {
+		for (int i = 1; i < 15 && i < PV.size() && PV[i] != nullptr; i++) pvstr += PV[i]->move.toUSI() + ' ';
+		const auto& root = PV[0];
+		std::cout << std::fixed;
+		std::cout << "info pv " << pvstr << "depth " << std::setprecision(2) << root->mass << " seldepth " << (PV.size() - 1)
+			<< " score cp " << static_cast<int>(root->eval) << " nodes " << tree.getNodeCount() << std::endl;
+	}
 	const auto bestchild = tree.getBestMove();
 	if (bestchild == nullptr) {
 		//std::cout << "info string error no children" << std::endl;
 		std::cout << "bestmove resign" << std::endl;
 		return;
 	}
-	std::cout << "info pv " << bestchild->move.toUSI() << " depth " << std::setprecision(2) << bestchild->mass.load() <<
-		" score cp " << static_cast<int>(-bestchild->eval) << " nodes " << tree.getNodeCount() << std::endl;
 	std::cout << "bestmove " << bestchild->move.toUSI() << std::endl;
 	tree.proceed(bestchild);
 	releaseAgentAndBranch(root, {bestchild});

--- a/ShogiStudyThird/commander.cpp
+++ b/ShogiStudyThird/commander.cpp
@@ -255,7 +255,7 @@ void Commander::setTsDistribution() {
 		case 4:
 		{
 			const double minlog = std::log(Ts_min), maxlog = std::log(Ts_max);
-			const double c = (minlog + maxlog) / 80.0;
+			const double c = (minlog + maxlog) / 40.0;
 			const double a = 1.0 / (std::exp((maxlog - minlog) / (c * 2.0)) - 1.0);
 			for (int i = 0; i < agentNum; i++) {
 				const double p = (double)i / (agentNum - 1.0);

--- a/ShogiStudyThird/node.cpp
+++ b/ShogiStudyThird/node.cpp
@@ -197,7 +197,7 @@ double SearchNode::getEs()const {
 		return eval * (1 - Es_c) + origin_eval * Es_c;
 	case 20: {
 		const double x = mass.load();
-		double p = Es_c * ((x >= 1) ? (1 / x*x) : 1);
+		double p = Es_c * ((x >= 1) ? (1 / (x*x)) : 1);
 		return eval * (1.0 - p) + origin_eval * p;
 	}
 	}
@@ -212,7 +212,7 @@ SearchNode* SearchNode::getBestChild()const {
 			double min = std::numeric_limits<double>::max();
 			for (const auto child : children) {
 				const double e = child->eval - child->mass * PV_c;
-				if (e <= min) {
+				if (e < min) {
 					best = child;
 					min = e;
 				}
@@ -247,7 +247,7 @@ SearchNode* SearchNode::getBestChild()const {
 				const double x = child->mass.load();
 				double p = PV_c * ((x >= 1) ? (1 / x) : 1);
 				const double e = child->eval * (1.0 - p) + origin_eval * p;
-				if (e <= min) {
+				if (e < min) {
 					best = child;
 					min = e;
 				}


### PR DESCRIPTION
Es20の式を修正
指す直前の読み筋表示をPVに変更
getBestChildの最小値比較から等号を削除（静止探索の結果でソートしているので、評価値が等しい場合はインデックスが若い方が有望である可能性が高い）
getBestChildの定数を変更