### PR TITLE
子ノードの生成手順を変更

### DIFF
--- a/ShogiStudyThird/agent.cpp
+++ b/ShogiStudyThird/agent.cpp
@@ -136,12 +136,18 @@ size_t SearchAgent::simulate(SearchNode* const root) {
 				goto backup;
 			}*/
 		}
-		MoveGenerator::genMove(node, player.kyokumen);
-		if (node->children.empty()) {
-			node->setMate();
-			goto backup;
+		{//子ノード生成
+			const auto moves = MoveGenerator::genMove(node, player.kyokumen);
+			if (moves.empty()) {
+				node->setMate();
+				goto backup;
+			}
+			node->children.reserve(moves.size());//合法手の数だけchildrenの領域を確保しておく(メモリの再確保と過剰確保を抑制する)
+			newnodecount += moves.size();
+			for (const auto move : moves) {
+				node->addChild(move);
+			}
 		}
-		newnodecount += node->children.size();
 		for (auto child : node->children) {
 			const auto cache = player.proceedC(child->move);
 			qsimulate(child, player, history.size());

--- a/ShogiStudyThird/move_gen.cpp
+++ b/ShogiStudyThird/move_gen.cpp
@@ -339,8 +339,9 @@ void genGoteUchiMove(EvaluatedNodes& en, const Kyokumen& kyokumen,const Bitboard
 	}
 }
 
-void MoveGenerator::genMove(SearchNode* parent, const Kyokumen& kyokumen) {
-	EvaluatedParent en(parent);
+std::vector<Move> MoveGenerator::genMove(SearchNode* parent, const Kyokumen& kyokumen) {
+	GeneratedMoves en;
+	en.moves.reserve(512);
 	if (kyokumen.teban()) {
 		auto kusemono = kyokumen.getSenteOuCheck(parent->move);
 		if (kusemono.size() > 0) {
@@ -373,7 +374,7 @@ void MoveGenerator::genMove(SearchNode* parent, const Kyokumen& kyokumen) {
 			genGoteOuMove(en, kyokumen, ~kyokumen.getGoteBB());
 		}
 	}
-	return;
+	return en.moves;
 }
 
 std::vector<Move> MoveGenerator::genCapMove(Move& move, const Kyokumen& kyokumen) {

--- a/ShogiStudyThird/move_gen.h
+++ b/ShogiStudyThird/move_gen.h
@@ -6,7 +6,7 @@
 class MoveGenerator {
 public:
 	static void genAllMove(SearchNode* parent, const Kyokumen&);
-	static void genMove(SearchNode* parent, const Kyokumen&);
+	static std::vector<Move> genMove(SearchNode* parent, const Kyokumen&);
 	static std::vector<Move> genCapMove(Move& move, const Kyokumen&);
 	static std::vector<Move> genNocapMove(Move& move, const Kyokumen&);
 };

--- a/ShogiStudyThird/stest.cpp
+++ b/ShogiStudyThird/stest.cpp
@@ -141,9 +141,8 @@ bool ShogiTest::genCapMoveCheck(std::string parent_sfen) {
 	Kyokumen k(usi::split(parent_sfen, ' '));
 	Move m;
 	SearchNode* const root = new SearchNode(m);
-	MoveGenerator::genMove(root, k);
-	const auto& moves = root->children;
-	strv msv; for (const auto& m : moves)msv.push_back(m->move.toUSI());
+	const auto& moves = MoveGenerator::genMove(root, k);
+	strv msv; for (const auto& m : moves)msv.push_back(m.toUSI());
 	const auto cmoves = MoveGenerator::genCapMove(m, k);
 	strv cmsv; for (const auto& m : cmoves)cmsv.push_back(m.toUSI());
 
@@ -219,7 +218,11 @@ bool ShogiTest::checkRecede(std::string sfen,const int depth) {
 }
 
 bool ShogiTest::checkRecedeR(Kyokumen& k, Feature& f, SearchNode* p, const int depth) {
-	MoveGenerator::genMove(p, k);
+	const auto moves = MoveGenerator::genMove(p, k);
+	p->children.reserve(moves.size());
+	for (const auto move : moves) {
+		p->addChild(move);
+	}
 	const Kyokumen ck = k;
 	const Feature cf = f;
 	for (const auto& c : p->children) {


### PR DESCRIPTION
合法手を生成し終わった後に、子ノードを生成するように変更した
合法手の数が分かっているので、childrenの領域をreserveして省メモリ化を図っている