### PR TITLE
agent::simulateにおいてrootNodeとrootPlayerの不整合が起こる場合があったので修正

### DIFF
--- a/ShogiStudyThird/agent.cpp
+++ b/ShogiStudyThird/agent.cpp
@@ -48,6 +48,7 @@ size_t SearchAgent::simulate(SearchNode* const root) {
 	std::vector<std::pair<uint64_t, std::array<uint8_t, 95>>> k_history;
 	//選択
 	while (!node->isLeaf()) {
+		if (!alive) return 0;
 		double CE = std::numeric_limits<double>::max();
 		std::vector<dn> evals;
 		for (const auto& child : node->children) {
@@ -88,6 +89,7 @@ size_t SearchAgent::simulate(SearchNode* const root) {
 	}
 	//展開・評価
 	{
+		if (!alive) return 0;
 		//末端ノードが他スレッドで展開中になっていないかチェック
 		LeafGuard dredear(node);
 		if (!dredear.Result()) {


### PR DESCRIPTION
simulateの開始時からplayer取得までの間にtree.proceedが入ると指し手と局面データに不整合が起こる
対策として探索木を下るときに生存フラグをチェックするようにした（tree.proceedが発生していた場合、agent.aliveは偽であるため）
player取得の際だけのチェックにしなかったのは、古くなったagentの探索切り上げが早くなる効果を期待しているためである
この修正により稀にあったクラッシュは発生しなくなると考えられる