### PR TITLE
ノード消去のタイミングを修正

### DIFF
--- a/ShogiStudyThird/commander.cpp
+++ b/ShogiStudyThird/commander.cpp
@@ -474,8 +474,8 @@ void Commander::chakushu(SearchNode* const bestchild) {
 	std::cout << "info pv " << pvstr << "depth " << std::setprecision(2) << root->mass << " seldepth " << depth
 		<< " score cp " << static_cast<int>(root->eval) << " nodes " << SearchNode::getNodeCount() << std::endl;
 	std::cout << "bestmove " << bestchild->move.toUSI() << std::endl;
-	tree.proceed(bestchild);
 	releaseAgent();
+	tree.proceed(bestchild);
 	if (permitPonder) {
 		startAgent();
 	}
@@ -492,11 +492,13 @@ void Commander::position(const std::vector<std::string>& tokens) {
 void Commander::releaseAgent() {
 	if (agents.empty())return;
 	if (deleteThread.joinable()) deleteThread.join();
+	tree.pause_deleteTree();
 	auto tmpthread =  std::thread(
-		[prevAgents = std::move(agents)]{
+		[&,prevAgents = std::move(agents)]{
 			for (auto& ag : prevAgents) {
 				ag->terminate();
 			}
+			tree.restart_deleteTree();
 		});
 	deleteThread.swap(tmpthread);
 	agents.clear();

--- a/ShogiStudyThird/tree.cpp
+++ b/ShogiStudyThird/tree.cpp
@@ -11,7 +11,8 @@ SearchTree::SearchTree()
 }
 
 SearchTree::~SearchTree() {
-	enable_deleteTrees = false;
+	enable_deleteTrees = true;
+	alive_deleteTrees = false;
 	cv_deleteTrees.notify_one();
 	auto root = getGameRoot();
 	delete root;
@@ -212,11 +213,12 @@ void SearchTree::deleteTrees(SearchNode::Children* root) {
 
 void SearchTree::deleteTreesLoop() {
 	enable_deleteTrees = true;
+	alive_deleteTrees = true;
 	std::unique_lock<std::mutex> lock(mtx_deleteTrees);
-	while (enable_deleteTrees) {
-		cv_deleteTrees.wait(lock, [this] {return !enable_deleteTrees || !roots_deleteTrees.empty(); });
+	while (alive_deleteTrees || !roots_deleteTrees.empty()) {
+		cv_deleteTrees.wait(lock, [this] {return enable_deleteTrees && !roots_deleteTrees.empty(); });
 		while (true) {
-			if (roots_deleteTrees.empty()) {
+			if (roots_deleteTrees.empty() || !enable_deleteTrees) {
 				break;
 			}
 			auto root = roots_deleteTrees.front();

--- a/ShogiStudyThird/tree.h
+++ b/ShogiStudyThird/tree.h
@@ -22,6 +22,8 @@ public:
 	SearchNode* getBestMove()const;//最もevalの高いrootのchildを返す
 	std::vector<SearchNode*> getPV()const;//rootからのpvの連なりを返す
 	void proceed(SearchNode* node);
+	void pause_deleteTree() { enable_deleteTrees = false; }
+	void restart_deleteTree() { enable_deleteTrees = true; }
 
 	const uint64_t getEvaluationCount()const { return evaluationcount; }
 	const std::vector<SearchNode*>& getHistory()const { return history; }
@@ -54,6 +56,7 @@ private:
 	std::condition_variable cv_deleteTrees;
 	std::mutex mtx_deleteTrees;
 	std::atomic_bool enable_deleteTrees;
+	std::atomic_bool alive_deleteTrees;
 
 	friend class Commander;
 	friend class ShogiTest;


### PR DESCRIPTION
スレッドが生き残っている途中でノードを消去してしまっていたので、スレッドの終了を待ってからノード消去するように変更